### PR TITLE
Add timeline history for multi-move predictions

### DIFF
--- a/src/oracle/domain/__init__.py
+++ b/src/oracle/domain/__init__.py
@@ -51,17 +51,52 @@ class MovePrediction:
 
 
 @dataclass
+class PredictionSnapshot:
+    """Snapshot of the prediction for a truncated PGN sequence."""
+
+    ply: int
+    pgn: str
+    moves: list[MovePrediction]
+    current_win_percentage: float
+    is_white_to_move: bool
+
+    @property
+    def san(self) -> str:
+        """Return the SAN sequence associated with the snapshot."""
+
+        lines = [line for line in self.pgn.splitlines() if line.strip()]
+        return lines[-1] if lines else ""
+
+
+@dataclass
 class PredictionResult:
     """Structured predictions returned by the prediction service."""
 
-    moves: list[MovePrediction]
-    current_win_percentage: float
+    history: list[PredictionSnapshot] = field(default_factory=list)
     metrics: PredictionMetrics = field(default_factory=PredictionMetrics)
+
+    @property
+    def moves(self) -> list[MovePrediction]:
+        """Expose the moves from the most recent snapshot for compatibility."""
+
+        return self.history[-1].moves if self.history else []
+
+    @property
+    def current_win_percentage(self) -> float:
+        """Expose the evaluation from the most recent snapshot for compatibility."""
+
+        return self.history[-1].current_win_percentage if self.history else 0.0
+
+    def last(self) -> PredictionSnapshot | None:
+        """Return the latest prediction snapshot when available."""
+
+        return self.history[-1] if self.history else None
 
 
 __all__ = [
     "OracleConfig",
     "PredictionMetrics",
     "MovePrediction",
+    "PredictionSnapshot",
     "PredictionResult",
 ]

--- a/src/oracle/web/app.py
+++ b/src/oracle/web/app.py
@@ -167,7 +167,8 @@ async def analyze(request: Request, pgn: str = Form(...)) -> HTMLResponse:
 
     context = {
         **base_context,
-        "predictions": prediction.moves,
+        "history": prediction.history,
+        "latest": prediction.last(),
         "current_win_percentage": prediction.current_win_percentage,
         "metrics": prediction.metrics,
     }

--- a/src/oracle/web/templates/result.html
+++ b/src/oracle/web/templates/result.html
@@ -96,37 +96,94 @@
           </div>
 
           <div class="card p-4 mb-4">
-            <h2 class="h5 mb-3">
-              Coups les plus probables
-              <span class="visually-hidden">Predicted Moves</span>
-            </h2>
-            <div class="table-responsive">
-              <table class="table table-hover align-middle">
-                <thead class="table-light">
-                  <tr>
-                    <th scope="col">#</th>
-                    <th scope="col">Coup</th>
-                    <th scope="col">Probabilité</th>
-                    <th scope="col">Évaluation</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for prediction in predictions %}
-                  <tr>
-                    <th scope="row">{{ loop.index }}</th>
-                    <td>
-                      <span class="fw-semibold">{{ prediction.move }}{{ prediction.notation }}</span>
-                      {% if prediction.is_best_move %}
-                      <span class="badge bg-success ms-2">Meilleur coup</span>
-                      {% endif %}
-                    </td>
-                    <td>{{ '%.2f'|format(prediction.likelihood) }}%</td>
-                    <td>{{ '%.2f'|format(prediction.win_percentage) }}%</td>
-                  </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
+            <h2 class="h5 mb-3">Explorer les coups</h2>
+            {% if history %}
+            {% set active_index = history|length - 1 %}
+            <ul class="nav nav-tabs flex-wrap" id="prediction-tabs" role="tablist">
+              {% for snapshot in history %}
+              {% set tab_id = 'position-' ~ loop.index0 %}
+              <li class="nav-item" role="presentation">
+                <button
+                  class="nav-link {% if loop.index0 == active_index %}active{% endif %}"
+                  id="{{ tab_id }}-tab"
+                  data-bs-toggle="tab"
+                  data-bs-target="#{{ tab_id }}"
+                  type="button"
+                  role="tab"
+                  aria-controls="{{ tab_id }}"
+                  aria-selected="{{ 'true' if loop.index0 == active_index else 'false' }}"
+                >
+                  {{ loop.index }}. {{ snapshot.san or 'Début de partie' }}
+                </button>
+              </li>
+              {% endfor %}
+            </ul>
+            <div class="tab-content pt-3" id="prediction-tabs-content">
+              {% for snapshot in history %}
+              {% set tab_id = 'position-' ~ loop.index0 %}
+              <div
+                class="tab-pane fade {% if loop.index0 == active_index %}show active{% endif %}"
+                id="{{ tab_id }}"
+                role="tabpanel"
+                aria-labelledby="{{ tab_id }}-tab"
+              >
+                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                  <div>
+                    <h3 class="h6 mb-1">
+                      Trait aux {{ 'blancs' if snapshot.is_white_to_move else 'noirs' }}
+                    </h3>
+                    <p class="mb-0 text-secondary">
+                      PGN : {{ snapshot.san or 'Début de partie' }}
+                    </p>
+                  </div>
+                  <span class="badge bg-secondary">#{{ loop.index }}</span>
+                </div>
+                <div class="table-responsive mt-3">
+                  {% if snapshot.moves %}
+                  <table class="table table-hover align-middle">
+                    <thead class="table-light">
+                      <tr>
+                        <th scope="col">#</th>
+                        <th scope="col">Coup</th>
+                        <th scope="col">Probabilité</th>
+                        <th scope="col">Évaluation</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for prediction in snapshot.moves %}
+                      <tr>
+                        <th scope="row">{{ loop.index }}</th>
+                        <td>
+                          <span class="fw-semibold">{{ prediction.move }}{{ prediction.notation }}</span>
+                          {% if prediction.is_best_move %}
+                          <span class="badge bg-success ms-2">Meilleur coup</span>
+                          {% endif %}
+                        </td>
+                        <td>{{ '%.2f'|format(prediction.likelihood) }}%</td>
+                        <td>{{ '%.2f'|format(prediction.win_percentage) }}%</td>
+                      </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                  {% else %}
+                  <p class="mb-0 text-secondary">
+                    Aucun coup légal disponible pour cette position.
+                  </p>
+                  {% endif %}
+                </div>
+                <p class="mt-3 mb-0 text-secondary">
+                  Évaluation actuelle :
+                  <strong>{{ '%.2f'|format(snapshot.current_win_percentage) }}%</strong>
+                  de chances pour les blancs.
+                </p>
+              </div>
+              {% endfor %}
             </div>
+            {% else %}
+            <p class="mb-0 text-secondary">
+              Aucune prédiction n'a pu être générée pour ce PGN.
+            </p>
+            {% endif %}
           </div>
 
           <div class="card p-4 mb-4">
@@ -185,5 +242,6 @@
         </div>
       </div>
     </main>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/tests/units/test_oracle_one_move.py
+++ b/tests/units/test_oracle_one_move.py
@@ -126,6 +126,7 @@ def test_cli_main_uses_factory_with_simulated_adapters(monkeypatch, caplog):
         "cli-token",
         "cli/model",
         "/fake/stockfish",
+        "q",
     ])
 
     monkeypatch.setattr("builtins.input", lambda _prompt="": responses.popleft())
@@ -149,4 +150,4 @@ def test_cli_main_uses_factory_with_simulated_adapters(monkeypatch, caplog):
     first_move = wrapper.last_result.moves[0].move
     assert first_move in caplog.text
     assert "Likelihood" in caplog.text
-    assert "Current Evaluation" in caplog.text
+    assert "Évaluation actuelle" in caplog.text

--- a/tests/units/web/test_app.py
+++ b/tests/units/web/test_app.py
@@ -136,6 +136,6 @@ def test_analyze_endpoint_returns_predictions(monkeypatch):
     assert captured["stockfish_path"] == "/fake/stockfish"
     assert captured["huggingface_model"] == "test/model"
     assert captured["huggingface_token"] == "api-token"
-    assert "Predicted Moves" in response.text
+    assert "Explorer les coups" in response.text
     first_move = wrapper.last_result.moves[0].move
     assert first_move in response.text


### PR DESCRIPTION
## Summary
- extend the domain model with `PredictionSnapshot` so results keep a full history of analysed positions
- replay games half-move by half-move in `PredictNextMoves` and expose the timeline to the CLI and FastAPI UI
- redesign the result page with Bootstrap tabs and make the CLI navigable per position while covering the new flow with unit tests

## Testing
- poetry run ruff check . --fix
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d071c7f2d48327bf6cb331b34e65d7