### PR TITLE
Add level selection to web UI and propagate through predictions

### DIFF
--- a/src/oracle/application/ports.py
+++ b/src/oracle/application/ports.py
@@ -45,5 +45,5 @@ class MoveAnalyzer(Protocol):
 class PredictNextMovesUseCase(Protocol):
     """Application use case for predicting the next chess moves."""
 
-    def execute(self, pgn: str) -> PredictionResult:
+    def execute(self, pgn: str, selected_level: int | None = None) -> PredictionResult:
         """Predict the next moves for the given PGN string."""

--- a/src/oracle/domain/__init__.py
+++ b/src/oracle/domain/__init__.py
@@ -29,8 +29,27 @@ class OracleConfig:
     rating_buckets: list[int] = field(
         default_factory=lambda: [1200, 1500, 1800, 2100]
     )
+    level_time_controls: dict[int, str] = field(
+        default_factory=lambda: {
+            800: "120+0",
+            1200: "300+2",
+            1600: "900+10",
+            2000: "3600+30",
+        }
+    )
     huggingface_client: Any | None = None
     engine_factory: Callable[[str], Any] | None = None
+
+    @property
+    def available_levels(self) -> tuple[int, ...]:
+        """Expose the configured player levels sorted increasingly."""
+
+        return tuple(sorted(self.level_time_controls))
+
+    def time_control_for_level(self, level: int) -> str | None:
+        """Return the configured time control for a given level when available."""
+
+        return self.level_time_controls.get(level)
 
 
 @dataclass

--- a/src/oracle/web/templates/index.html
+++ b/src/oracle/web/templates/index.html
@@ -203,6 +203,22 @@
                     </div>
                     <textarea class="form-control" id="pgn" name="pgn" required>{{ pgn or "" }}</textarea>
                   </div>
+                  <div class="col-12 col-md-6">
+                    <label for="level" class="form-label fw-semibold">Niveau (optionnel)</label>
+                    <select class="form-select" id="level" name="level">
+                      <option value="" {% if not selected_level %}selected{% endif %}>
+                        Utiliser les Elo du PGN
+                      </option>
+                      {% for option in levels or [] %}
+                      <option value="{{ option.value }}" {% if selected_level == option.value %}selected{% endif %}>
+                        {{ option.label }}
+                      </option>
+                      {% endfor %}
+                    </select>
+                    <div class="form-text">
+                      Choisissez un niveau cible pour ignorer les Elo du PGN et appliquer la cadence correspondante.
+                    </div>
+                  </div>
                   <div class="col-12 d-flex justify-content-end">
                     <button type="submit" class="btn btn-primary">
                       <span class="me-2" aria-hidden="true">♟️</span>

--- a/tests/units/test_oracle_one_move.py
+++ b/tests/units/test_oracle_one_move.py
@@ -67,9 +67,9 @@ class CapturingUseCase:
     def config(self) -> Any:
         return self._inner.config
 
-    def execute(self, pgn: str):
+    def execute(self, pgn: str, selected_level: int | None = None):
         self.last_pgn = pgn
-        result = self._inner.execute(pgn)
+        result = self._inner.execute(pgn, selected_level=selected_level)
         self.last_result = result
         return result
 


### PR DESCRIPTION
## Summary
- expose level presets in `OracleConfig` and allow `PredictNextMoves` to override PGN metadata with a chosen level
- surface level selection in the FastAPI form, validate it server-side, and forward it to the prediction service
- expand FastAPI and application tests to cover level selection, validation, and Elo propagation

## Testing
- python -m ruff check . --fix
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0821114948327a3510a040a5dc754