### PR TITLE
Enforce play mode time control

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Oracle is the first chess engine that plays like a human, from amateur to super 
 
 L’application web d’Oracle s’appuie sur FastAPI et Jinja2 : la page d’accueil accessible sur `/` affiche un formulaire de saisie de PGN tandis que l’endpoint `/analyze` exécute l’analyse avant de renvoyer la page de résultats avec les coups probables et les métriques associées. L’interface adopte Bootstrap et un thème inspiré de GitHub pour offrir une expérience utilisateur claire et soignée.
 
+### Modes disponibles
+
+- **Analyse** : mode historique de l’application, il exploite les métadonnées présentes dans votre PGN (Elo, cadence) ou celles fournies dans le formulaire pour ajuster les recommandations.
+- **Jouer contre l’ordinateur** : un second onglet « jouer » démarre une partie interactive contre Oracle. Le niveau Elo sélectionné module toujours la force de l’adversaire, mais la cadence est verrouillée à 10 minutes (`600+0`). Le serveur enrichit automatiquement le PGN transmis avec cet en-tête `TimeControl` afin que la détection du type de partie et l’ajustement des évaluations reflètent bien ce format rapide.
+
 ### Prérequis
 
 1. **Moteur Stockfish** : installez Stockfish localement et exportez son chemin absolu dans la variable d’environnement `STOCKFISH_PATH`. Sans cette variable, l’interface affiche un message d’erreur détaillé permettant de corriger la configuration.

--- a/src/oracle/application/ports.py
+++ b/src/oracle/application/ports.py
@@ -45,5 +45,11 @@ class MoveAnalyzer(Protocol):
 class PredictNextMovesUseCase(Protocol):
     """Application use case for predicting the next chess moves."""
 
-    def execute(self, pgn: str, selected_level: int | None = None) -> PredictionResult:
+    def execute(
+        self,
+        pgn: str,
+        selected_level: int | None = None,
+        *,
+        mode: str | None = None,
+    ) -> PredictionResult:
         """Predict the next moves for the given PGN string."""

--- a/src/oracle/domain/__init__.py
+++ b/src/oracle/domain/__init__.py
@@ -37,6 +37,7 @@ class OracleConfig:
             2000: "3600+30",
         }
     )
+    play_mode_time_control: str = "600+0"
     huggingface_client: Any | None = None
     engine_factory: Callable[[str], Any] | None = None
 
@@ -46,10 +47,21 @@ class OracleConfig:
 
         return tuple(sorted(self.level_time_controls))
 
-    def time_control_for_level(self, level: int) -> str | None:
-        """Return the configured time control for a given level when available."""
+    def time_control_for_level(
+        self, level: int, mode: str | None = None
+    ) -> str | None:
+        """Return the time control associated with a level, accounting for the mode."""
 
+        if mode == "play":
+            return self.play_mode_time_control
         return self.level_time_controls.get(level)
+
+    def time_control_for_mode(self, mode: str) -> str | None:
+        """Expose the default time control for a specific interaction mode."""
+
+        if mode == "play":
+            return self.play_mode_time_control
+        return None
 
 
 @dataclass

--- a/tests/units/test_oracle_one_move.py
+++ b/tests/units/test_oracle_one_move.py
@@ -67,9 +67,15 @@ class CapturingUseCase:
     def config(self) -> Any:
         return self._inner.config
 
-    def execute(self, pgn: str, selected_level: int | None = None):
+    def execute(
+        self, pgn: str, selected_level: int | None = None, *, mode: str | None = None
+    ):
         self.last_pgn = pgn
-        result = self._inner.execute(pgn, selected_level=selected_level)
+        result = self._inner.execute(
+            pgn,
+            selected_level=selected_level,
+            mode=mode,
+        )
         self.last_result = result
         return result
 

--- a/tests/units/web/test_app.py
+++ b/tests/units/web/test_app.py
@@ -83,15 +83,23 @@ class CapturingUseCase:
         self.last_pgn: str | None = None
         self.last_result = None
         self.last_selected_level: int | None = None
+        self.last_mode: str | None = None
 
     @property
     def config(self) -> Any:
         return self._inner.config
 
-    def execute(self, pgn: str, selected_level: int | None = None):
+    def execute(
+        self, pgn: str, selected_level: int | None = None, *, mode: str | None = None
+    ):
         self.last_pgn = pgn
         self.last_selected_level = selected_level
-        result = self._inner.execute(pgn, selected_level=selected_level)
+        self.last_mode = mode
+        result = self._inner.execute(
+            pgn,
+            selected_level=selected_level,
+            mode=mode,
+        )
         self.last_result = result
         return result
 
@@ -276,6 +284,9 @@ def test_play_move_endpoint_returns_computer_move(monkeypatch):
     node = game.end()
     assert node.board().fen() == data["fen"]
     assert wrapper.last_selected_level == 1600
+    assert wrapper.last_mode == "play"
+    expected_header = f'[TimeControl "{wrapper.config.play_mode_time_control}"]'
+    assert expected_header in wrapper.last_pgn
 
 
 def test_play_move_endpoint_rejects_missing_pgn(monkeypatch):


### PR DESCRIPTION
## Summary
- add a dedicated 10-minute play mode time control to `OracleConfig` and allow the prediction use case to receive the active mode
- update the web play endpoint to inject the time-control header before invoking the use case and ensure play requests pass the mode
- add tests for the play cadence and document the new "jouer" option in the web interface section of the README

## Testing
- poetry run ruff check . --fix
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d098814180832783213033663bff16