### PR TITLE
feat(web): polish dark theme layout

### DIFF
--- a/src/oracle/web/static/github-dark.css
+++ b/src/oracle/web/static/github-dark.css
@@ -1,0 +1,416 @@
+:root {
+  color-scheme: dark;
+  --bs-body-bg: #0d1117;
+  --bs-body-bg-rgb: 13, 17, 23;
+  --bs-body-color: #c9d1d9;
+  --bs-body-color-rgb: 201, 209, 217;
+  --bs-body-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
+    sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --bs-body-secondary-color: #8b949e;
+  --bs-body-secondary-bg: #151b23;
+  --bs-body-tertiary-color: #8b949e;
+  --bs-body-tertiary-bg: #10161d;
+  --bs-heading-color: #f0f6fc;
+  --bs-border-color: #30363d;
+  --bs-border-width: 1px;
+  --bs-card-bg: #161b22;
+  --bs-card-border-color: #30363d;
+  --bs-card-color: var(--bs-body-color);
+  --bs-card-cap-bg: #161b22;
+  --bs-link-color: #1f6feb;
+  --bs-link-hover-color: #58a6ff;
+  --bs-primary: #1f6feb;
+  --bs-primary-rgb: 31, 111, 235;
+  --bs-primary-text-emphasis: #8cb6ff;
+  --bs-primary-bg-subtle: #0d419d;
+  --bs-primary-border-subtle: #1f6feb;
+  --bs-success: #238636;
+  --bs-success-rgb: 35, 134, 54;
+  --bs-success-text-emphasis: #2ea043;
+  --bs-success-bg-subtle: #113417;
+  --bs-success-border-subtle: #1c5230;
+  --bs-info: #1f6feb;
+  --bs-info-rgb: 31, 111, 235;
+  --bs-info-text-emphasis: #8cb6ff;
+  --bs-info-bg-subtle: #0d419d;
+  --bs-info-border-subtle: #1f6feb;
+  --bs-danger: #f85149;
+  --bs-danger-rgb: 248, 81, 73;
+  --bs-danger-text-emphasis: #ffaba8;
+  --bs-danger-bg-subtle: #4d0c15;
+  --bs-danger-border-subtle: #932834;
+  --bs-warning: #d29922;
+  --bs-warning-rgb: 210, 153, 34;
+  --bs-warning-text-emphasis: #e3b341;
+  --bs-warning-bg-subtle: #332204;
+  --bs-warning-border-subtle: #8b5e10;
+  --bs-light: #21262d;
+  --bs-light-rgb: 33, 38, 45;
+  --bs-light-text-emphasis: #f0f6fc;
+  --bs-light-bg-subtle: #1c2128;
+  --bs-light-border-subtle: #30363d;
+  --bs-dark: #010409;
+  --bs-dark-rgb: 1, 4, 9;
+  --bs-code-color: #79c0ff;
+  --bs-highlight-bg: #7f4a1d;
+  --bs-table-color: var(--bs-body-color);
+  --bs-table-bg: transparent;
+  --bs-table-border-color: #30363d;
+  --bs-table-striped-color: var(--bs-body-color);
+  --bs-table-striped-bg: rgba(48, 54, 61, 0.35);
+  --bs-table-active-color: var(--bs-body-color);
+  --bs-table-active-bg: rgba(48, 54, 61, 0.5);
+  --bs-table-hover-color: var(--bs-body-color);
+  --bs-table-hover-bg: rgba(48, 54, 61, 0.45);
+  --bs-focus-ring-color: rgba(31, 111, 235, 0.45);
+}
+
+body {
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  font-family: var(--bs-body-font-family);
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top left, rgba(56, 139, 253, 0.12), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(35, 134, 54, 0.12), transparent 50%),
+    var(--bs-body-bg);
+}
+
+.app-main {
+  flex: 1 0 auto;
+  padding-block: clamp(2rem, 4vw, 3.5rem);
+}
+
+.app-footer {
+  padding-block: 2.5rem;
+  color: var(--bs-body-secondary-color);
+}
+
+.app-nav {
+  background: rgba(13, 17, 23, 0.85);
+  border-bottom: 1px solid var(--bs-border-color);
+  backdrop-filter: saturate(180%) blur(18px);
+  padding-block: 1rem;
+}
+
+.app-nav .navbar-brand {
+  color: var(--bs-heading-color) !important;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+main {
+  color: var(--bs-body-color);
+}
+
+.card {
+  border-radius: 16px;
+  border: 1px solid var(--bs-card-border-color);
+  background-color: rgba(22, 27, 34, 0.92);
+  color: var(--bs-card-color);
+  box-shadow: 0 20px 45px rgba(1, 4, 9, 0.4);
+  backdrop-filter: saturate(180%) blur(18px);
+}
+
+textarea,
+pre,
+.code-block {
+  background-color: var(--bs-body-secondary-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 8px;
+  color: var(--bs-body-color);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+textarea {
+  min-height: 320px;
+}
+
+textarea:focus {
+  border-color: var(--bs-primary);
+  box-shadow: 0 0 0 0.25rem rgba(31, 111, 235, 0.35);
+  outline: 0;
+}
+
+textarea[readonly] {
+  background-color: rgba(240, 246, 252, 0.08);
+  cursor: not-allowed;
+}
+
+.board-panel {
+  background-color: rgba(22, 27, 34, 0.92);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 16px;
+  padding: 1rem 1rem 1.5rem;
+  box-shadow: 0 16px 36px rgba(1, 4, 9, 0.45);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.board-panel__header {
+  font-size: 0.875rem;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--bs-body-secondary-color);
+}
+
+.board-panel__hint {
+  font-size: 0.875rem;
+  color: var(--bs-body-secondary-color);
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.board-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.board-summary {
+  background-color: rgba(31, 111, 235, 0.08);
+  border: 1px solid rgba(31, 111, 235, 0.25);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
+.board-summary dt {
+  color: var(--bs-heading-color);
+  font-weight: 600;
+}
+
+.board-summary dd {
+  margin-bottom: 0;
+  color: var(--bs-body-secondary-color);
+}
+
+@media (max-width: 991.98px) {
+  .form-label-group {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .board-panel,
+  .board-summary {
+    margin: 0 auto;
+  }
+}
+
+.form-label-group {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border-radius: 6px;
+  border-width: 1px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease, transform 0.1s ease;
+}
+
+.btn:focus-visible {
+  box-shadow: 0 0 0 4px rgba(56, 139, 253, 0.35);
+  outline: none;
+}
+
+.btn-sm {
+  padding-inline: 0.75rem;
+}
+
+.btn-primary {
+  color: #f0f6fc;
+  background-color: #238636;
+  border-color: rgba(27, 31, 36, 0.2);
+  box-shadow: 0 1px 0 rgba(1, 4, 9, 0.2);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background-color: #2ea043;
+  border-color: rgba(27, 31, 36, 0.2);
+}
+
+.btn-primary:active {
+  background-color: #1f6f31;
+  border-color: rgba(27, 31, 36, 0.35);
+  box-shadow: inset 0 1px 0 rgba(1, 4, 9, 0.3);
+  transform: translateY(1px);
+}
+
+.btn-outline-primary {
+  color: #58a6ff;
+  border-color: rgba(56, 139, 253, 0.5);
+  background-color: rgba(56, 139, 253, 0.12);
+}
+
+.btn-outline-primary:hover,
+.btn-outline-primary:focus,
+.btn-outline-primary.active,
+.btn-outline-primary:active,
+.btn-check:checked + .btn-outline-primary {
+  color: #f0f6fc;
+  background-color: rgba(56, 139, 253, 0.22);
+  border-color: rgba(56, 139, 253, 0.65);
+}
+
+.btn-outline-secondary {
+  color: var(--bs-body-color);
+  background-color: #21262d;
+  border-color: rgba(240, 246, 252, 0.08);
+}
+
+.btn-outline-secondary:hover,
+.btn-outline-secondary:focus {
+  color: var(--bs-heading-color);
+  background-color: #30363d;
+  border-color: rgba(240, 246, 252, 0.18);
+}
+
+.btn-outline-danger {
+  color: #ffaba8;
+  border-color: rgba(248, 81, 73, 0.45);
+  background-color: rgba(248, 81, 73, 0.08);
+}
+
+.btn-outline-danger:hover,
+.btn-outline-danger:focus,
+.btn-outline-danger:active {
+  color: #ffaba8;
+  background-color: rgba(248, 81, 73, 0.18);
+  border-color: rgba(248, 81, 73, 0.6);
+}
+
+.alert-danger {
+  border-left: 4px solid var(--bs-danger);
+  border-radius: 12px;
+}
+
+.alert-info {
+  color: var(--bs-info-text-emphasis);
+  background-color: rgba(31, 111, 235, 0.12);
+  border-color: rgba(31, 111, 235, 0.25);
+}
+
+.badge.bg-success {
+  background-color: var(--bs-success) !important;
+}
+
+.badge.bg-secondary {
+  background-color: rgba(110, 118, 129, 0.35) !important;
+  color: var(--bs-body-color);
+}
+
+.table {
+  border-color: var(--bs-border-color);
+}
+
+.table > :not(caption) > * > * {
+  background-color: transparent;
+  border-bottom: 1px solid var(--bs-border-color);
+}
+
+.table thead,
+.table-light {
+  color: var(--bs-body-color);
+  background-color: rgba(48, 54, 61, 0.35);
+}
+
+.table-hover tbody tr:hover {
+  background-color: var(--bs-table-hover-bg);
+}
+
+.nav-tabs {
+  border-bottom: 1px solid var(--bs-border-color);
+}
+
+.nav-tabs .nav-link {
+  color: var(--bs-body-color);
+  border: 1px solid transparent;
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+}
+
+.nav-tabs .nav-link:hover {
+  border-color: var(--bs-border-color);
+  background-color: rgba(48, 54, 61, 0.35);
+}
+
+.nav-tabs .nav-link.active {
+  color: var(--bs-heading-color);
+  background-color: var(--bs-card-bg);
+  border-color: var(--bs-border-color) var(--bs-border-color) var(--bs-card-bg);
+}
+
+pre {
+  padding: 1rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.code-block {
+  margin-bottom: 0;
+}
+
+.details-toggle summary {
+  cursor: pointer;
+}
+
+details summary {
+  cursor: pointer;
+}
+
+footer {
+  color: var(--bs-body-secondary-color);
+}
+
+.guide-section + .guide-section {
+  border-top: 1px solid var(--bs-border-color);
+  padding-top: 1.5rem;
+}
+
+.guide-section h3 {
+  letter-spacing: 0.08em;
+}
+
+.bg-light {
+  background-color: var(--bs-light-bg-subtle) !important;
+  border: 1px solid var(--bs-light-border-subtle) !important;
+  color: var(--bs-body-color);
+}
+
+.link-secondary {
+  color: var(--bs-body-secondary-color) !important;
+}
+
+.link-secondary:hover {
+  color: var(--bs-link-hover-color) !important;
+}
+
+small,
+.text-secondary {
+  color: var(--bs-body-secondary-color) !important;
+}
+
+a {
+  color: var(--bs-link-color);
+}
+
+a:hover {
+  color: var(--bs-link-hover-color);
+}

--- a/src/oracle/web/static/oracle-board.css
+++ b/src/oracle/web/static/oracle-board.css
@@ -1,1 +1,34 @@
-:root{--oracle-board-shadow: 0 20px 45px rgba(15, 23, 42, .15);--oracle-board-border: rgba(27, 31, 35, .08);--oracle-board-bg: linear-gradient(180deg, #fdfdfd 0%, #f6f8fa 100%)}#oracle-board{position:relative;width:100%;max-width:520px;margin:1rem auto;border-radius:18px;border:1px solid var(--oracle-board-border);background:var(--oracle-board-bg);box-shadow:var(--oracle-board-shadow);overflow:hidden}#oracle-board:after{content:"";position:absolute;top:0;right:0;bottom:0;left:0;border-radius:inherit;pointer-events:none;box-shadow:inset 0 0 0 1px #ffffffa6}@media (max-width: 768px){#oracle-board{margin:1.5rem auto;max-width:min(100%,420px)}}
+:root {
+  --oracle-board-shadow: 0 16px 34px rgba(1, 4, 9, 0.45);
+}
+
+#oracle-board {
+  position: relative;
+  width: 100%;
+  max-width: 520px;
+  margin: 1rem auto;
+  border-radius: 18px;
+  border: 1px solid var(--bs-border-color);
+  background: var(--bs-card-bg);
+  box-shadow: var(--oracle-board-shadow);
+  overflow: hidden;
+}
+
+#oracle-board::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(240, 246, 252, 0.08);
+}
+
+@media (max-width: 768px) {
+  #oracle-board {
+    margin: 1.5rem auto;
+    max-width: min(100%, 420px);
+  }
+}

--- a/src/oracle/web/templates/index.html
+++ b/src/oracle/web/templates/index.html
@@ -10,192 +10,49 @@
       integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
       crossorigin="anonymous"
     />
+    <link rel="stylesheet" href="{{ url_for('static', path='github-dark.css') }}" />
     <link rel="stylesheet" href="{{ url_for('static', path='oracle-board.css') }}" />
-    <style>
-      :root {
-        --github-bg: #f6f8fa;
-        --github-surface: #ffffff;
-        --github-border: #d0d7de;
-        --github-header: #24292f;
-        --github-primary: #0969da;
-        --github-danger: #cf222e;
-      }
-
-      body {
-        background-color: var(--github-bg);
-        color: #24292f;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
-          sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
-      }
-
-      .navbar {
-        background-color: var(--github-header);
-        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-      }
-
-      .navbar-brand {
-        color: #f6f8fa !important;
-        font-weight: 600;
-        letter-spacing: 0.02em;
-      }
-
-      .card {
-        border-radius: 12px;
-        border: 1px solid var(--github-border);
-        box-shadow: 0 1px 3px rgba(27, 31, 35, 0.12);
-      }
-
-      .board-panel {
-        background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
-        border: 1px solid var(--github-border);
-        border-radius: 16px;
-        padding: 1rem 1rem 1.5rem;
-        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        width: 100%;
-      }
-
-      .board-panel__header {
-        font-size: 0.875rem;
-        letter-spacing: 0.08em;
-        font-weight: 700;
-        text-transform: uppercase;
-        color: #57606a;
-        margin-bottom: 0.5rem;
-      }
-
-      .board-panel__hint {
-        font-size: 0.875rem;
-        color: #6b7280;
-        margin-top: 1rem;
-        text-align: center;
-      }
-
-      .board-actions {
-        display: flex;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-        justify-content: flex-end;
-      }
-
-      .form-label-group {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 0.75rem;
-      }
-
-      @media (max-width: 991.98px) {
-        .form-label-group {
-          flex-direction: column;
-          align-items: flex-start;
-        }
-
-        .board-panel {
-          margin: 0 auto;
-        }
-      }
-
-      textarea {
-        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-        background-color: var(--github-bg);
-        border-color: var(--github-border);
-        min-height: 320px;
-      }
-
-      textarea:focus {
-        border-color: var(--github-primary);
-        box-shadow: 0 0 0 0.25rem rgba(9, 105, 218, 0.25);
-      }
-
-      textarea[readonly] {
-        background-color: #e9ecef;
-        cursor: not-allowed;
-      }
-
-      .btn-primary {
-        background-color: var(--github-primary);
-        border-color: var(--github-primary);
-        font-weight: 600;
-      }
-
-      .btn-primary:hover {
-        background-color: #0a5bd3;
-        border-color: #0a5bd3;
-      }
-
-      .alert-danger {
-        border-left: 4px solid var(--github-danger);
-        border-radius: 12px;
-      }
-
-      footer {
-        color: #57606a;
-      }
-
-      .guide-section + .guide-section {
-        border-top: 1px solid var(--github-border);
-        padding-top: 1.5rem;
-      }
-
-      .guide-section h3 {
-        letter-spacing: 0.08em;
-      }
-
-      .code-block {
-        background-color: var(--github-bg);
-        border: 1px solid var(--github-border);
-        border-radius: 8px;
-        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-        font-size: 0.875rem;
-        margin-bottom: 0;
-        padding: 1rem;
-        white-space: pre-wrap;
-        word-break: break-word;
-      }
-    </style>
   </head>
-  <body>
-    <nav class="navbar navbar-dark">
-      <div class="container">
+  <body class="app-shell">
+    <nav class="app-nav navbar navbar-dark">
+      <div class="container-xxl px-4 px-lg-5">
         <a class="navbar-brand" href="/">Oracle Analyzer</a>
       </div>
     </nav>
-    <main class="container my-5">
-      <div class="row justify-content-center">
-        <div class="col-lg-10 col-xl-8">
-          {% if error %}
-          <div class="alert alert-danger" role="alert">
-            <h4 class="alert-heading">{{ error.title }}</h4>
-            <p class="mb-2">{{ error.detail }}</p>
-            {% if error.hint %}
-            <hr />
-            <p class="mb-0">{{ error.hint }}</p>
+    <main class="app-main">
+      <div class="container-xxl px-4 px-lg-5">
+        <div class="row g-4 justify-content-center">
+          <div class="col-12 col-xl-10 col-xxl-9">
+            {% if error %}
+            <div class="alert alert-danger" role="alert">
+              <h4 class="alert-heading">{{ error.title }}</h4>
+              <p class="mb-2">{{ error.detail }}</p>
+              {% if error.hint %}
+              <hr />
+              <p class="mb-0">{{ error.hint }}</p>
+              {% endif %}
+            </div>
             {% endif %}
-          </div>
-          {% endif %}
-          <div
-            class="card p-4"
-            data-app-root
-            data-active-mode="{{ active_mode or 'analyze' }}"
-            data-game-new-endpoint="/play/new"
-            data-game-move-endpoint="/play/move"
-            data-game-resign-endpoint="/play/resign"
-          >
-            <div class="row g-4 align-items-start">
-              <div class="col-lg-5 order-lg-2">
-                <div class="board-panel">
-                  <p class="board-panel__header mb-1">Plateau interactif</p>
-                  <div id="oracle-board"></div>
-                  <p class="board-panel__hint mb-0">
-                    Selon le mode sélectionné, le plateau se synchronise avec votre PGN ou envoie vos coups à l'ordinateur.
-                  </p>
+            <div
+              class="card p-4 p-lg-5"
+              data-app-root
+              data-active-mode="{{ active_mode or 'analyze' }}"
+              data-game-new-endpoint="/play/new"
+              data-game-move-endpoint="/play/move"
+              data-game-resign-endpoint="/play/resign"
+            >
+              <div class="row g-5 align-items-start">
+                <div class="col-lg-5 col-xl-4 order-lg-2">
+                  <div class="board-panel">
+                    <p class="board-panel__header mb-1">Plateau interactif</p>
+                    <div id="oracle-board"></div>
+                    <p class="board-panel__hint mb-0">
+                      Selon le mode sélectionné, le plateau se synchronise avec votre PGN ou envoie vos coups à l'ordinateur.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div class="col-lg-7 order-lg-1">
-                <div class="mb-4">
+                <div class="col-lg-7 col-xl-8 order-lg-1">
+                  <div class="mb-4">
                   <div class="btn-group" role="group" aria-label="Mode d'utilisation">
                     <input
                       type="radio"
@@ -304,104 +161,108 @@
                 </div>
               </div>
             </div>
-          </div>
-          <div class="card p-4 mt-4" id="guide">
-            <h2 class="h5 mb-3">Profiter pleinement d'Oracle</h2>
-            <p class="text-secondary">
-              Ce guide reprend les principales étapes de la documentation officielle pour préparer votre environnement,
-              lancer l'interface web et interpréter les prédictions fournies par Oracle.
-            </p>
-            <div class="guide-section pb-3">
-              <h3 class="h6 text-uppercase text-secondary fw-semibold">1. Préparer l'environnement</h3>
-              <p class="mb-2">
-                Oracle combine le moteur Stockfish et un modèle hébergé sur Hugging Face. Avant de démarrer le serveur,
-                vérifiez les éléments suivants&nbsp;:
+            <div class="card p-4 p-lg-5 mt-4" id="guide">
+              <h2 class="h5 mb-3">Profiter pleinement d'Oracle</h2>
+              <p class="text-secondary">
+                Ce guide reprend les principales étapes de la documentation officielle pour préparer votre environnement,
+                lancer l'interface web et interpréter les prédictions fournies par Oracle.
               </p>
-              <ul class="mb-0">
-                <li>
-                  Installez Stockfish localement et exportez son chemin absolu dans la variable d'environnement
-                  <code>STOCKFISH_PATH</code>.
-                </li>
-                <li>
-                  (Optionnel) Choisissez un modèle Hugging Face via <code>HUGGINGFACE_MODEL_ID</code> et renseignez
-                  <code>HUGGINGFACEHUB_API_TOKEN</code> si l'endpoint nécessite une authentification.
-                </li>
-                <li>
-                  Les paramètres par défaut (profondeur, temps, Elo, cadence) sont définis dans
-                  <code>OracleConfig</code> et peuvent être ajustés pour coller à votre usage (blitz, classique, etc.).
-                </li>
-              </ul>
-            </div>
-            <div class="guide-section pb-3">
-              <h3 class="h6 text-uppercase text-secondary fw-semibold">2. Démarrer le serveur web</h3>
-              <p>
-                Une fois les variables configurées, lancez l'application FastAPI avec Uvicorn. Le serveur se met en écoute par
-                défaut sur <code>http://127.0.0.1:8000/</code>&nbsp;:
-              </p>
-              <pre class="code-block">uvicorn src.oracle.web.app:app --reload</pre>
-              <p class="mb-0 mt-2">
-                Le mode <em>reload</em> recharge automatiquement le serveur lorsque vous modifiez le code pendant vos tests.
-              </p>
-            </div>
-            <div class="guide-section pb-3">
-              <h3 class="h6 text-uppercase text-secondary fw-semibold">3. Préparer un PGN à analyser</h3>
-              <p class="mb-2">
-                Oracle accepte un PGN complet jusqu'au coup que vous souhaitez prédire. Incluez les balises si vous les avez et
-                assurez-vous que la notation SAN est correcte.
-              </p>
-              <p class="text-secondary small mb-2">Exemple minimal&nbsp;:</p>
-              <pre class="code-block">[Event "Exemple"]
+              <div class="guide-section pb-3">
+                <h3 class="h6 text-uppercase text-secondary fw-semibold">1. Préparer l'environnement</h3>
+                <p class="mb-2">
+                  Oracle combine le moteur Stockfish et un modèle hébergé sur Hugging Face. Avant de démarrer le serveur,
+                  vérifiez les éléments suivants&nbsp;:
+                </p>
+                <ul class="mb-0">
+                  <li>
+                    Installez Stockfish localement et exportez son chemin absolu dans la variable d'environnement
+                    <code>STOCKFISH_PATH</code>.
+                  </li>
+                  <li>
+                    (Optionnel) Choisissez un modèle Hugging Face via <code>HUGGINGFACE_MODEL_ID</code> et renseignez
+                    <code>HUGGINGFACEHUB_API_TOKEN</code> si l'endpoint nécessite une authentification.
+                  </li>
+                  <li>
+                    Les paramètres par défaut (profondeur, temps, Elo, cadence) sont définis dans
+                    <code>OracleConfig</code> et peuvent être ajustés pour coller à votre usage (blitz, classique, etc.).
+                  </li>
+                </ul>
+              </div>
+              <div class="guide-section pb-3">
+                <h3 class="h6 text-uppercase text-secondary fw-semibold">2. Démarrer le serveur web</h3>
+                <p>
+                  Une fois les variables configurées, lancez l'application FastAPI avec Uvicorn. Le serveur se met en écoute par
+                  défaut sur <code>http://127.0.0.1:8000/</code>&nbsp;:
+                </p>
+                <pre class="code-block">uvicorn src.oracle.web.app:app --reload</pre>
+                <p class="mb-0 mt-2">
+                  Le mode <em>reload</em> recharge automatiquement le serveur lorsque vous modifiez le code pendant vos tests.
+                </p>
+              </div>
+              <div class="guide-section pb-3">
+                <h3 class="h6 text-uppercase text-secondary fw-semibold">3. Préparer un PGN à analyser</h3>
+                <p class="mb-2">
+                  Oracle accepte un PGN complet jusqu'au coup que vous souhaitez prédire. Incluez les balises si vous les avez et
+                  assurez-vous que la notation SAN est correcte.
+                </p>
+                <p class="text-secondary small mb-2">Exemple minimal&nbsp;:</p>
+                <pre class="code-block">[Event "Exemple"]
 [Site "Local"]
 [White "Joueur A"]
 [Black "Joueur B"]
 [Result "*"]
 
 1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 *</pre>
-              <p class="mb-0">
-                Collez le PGN ci-dessus (ou le vôtre) dans le formulaire, puis cliquez sur <strong>Analyser</strong> pour que
-                l'application calcule les coups probables suivants.
+                <p class="mb-0">
+                  Collez le PGN ci-dessus (ou le vôtre) dans le formulaire, puis cliquez sur <strong>Analyser</strong> pour que
+                  l'application calcule les coups probables suivants.
+                </p>
+              </div>
+              <div class="guide-section pb-3">
+                <h3 class="h6 text-uppercase text-secondary fw-semibold">4. Lire et exploiter les résultats</h3>
+                <p class="mb-2">
+                  La page de résultats présente&nbsp;:
+                </p>
+                <ul class="mb-0">
+                  <li>Le pourcentage de gain estimé pour les blancs dans la position actuelle.</li>
+                  <li>Un classement des coups probables avec leur probabilité et l'évaluation associée.</li>
+                  <li>Les métriques du modèle (tokens utilisés, coût estimé) pour suivre la consommation de l'API Hugging Face.</li>
+                  <li>Le PGN analysé pour vérification rapide et partage.</li>
+                </ul>
+              </div>
+              <div class="guide-section pb-1">
+                <h3 class="h6 text-uppercase text-secondary fw-semibold">5. Dépannage rapide</h3>
+                <ul class="mb-0">
+                  <li>Erreur sur <code>STOCKFISH_PATH</code>&nbsp;: vérifiez que le chemin pointe bien vers un binaire exécutable.</li>
+                  <li>PGN invalide&nbsp;: corrigez la notation SAN ou la numérotation des coups avant de relancer l'analyse.</li>
+                  <li>
+                    Temps de réponse ou coût élevés&nbsp;: sélectionnez un modèle Hugging Face plus léger ou ajustez les paramètres
+                    d'analyse dans <code>OracleConfig</code>.
+                  </li>
+                </ul>
+              </div>
+              <p class="mt-3 mb-0 small text-secondary">
+                Retrouvez davantage de détails (modes CLI, configuration avancée, exemples) dans le fichier
+                <a
+                  href="https://github.com/yoshachess/oracle/blob/main/README.md"
+                  class="link-secondary"
+                  target="_blank"
+                  rel="noopener"
+                  >README</a
+                >
+                du projet.
               </p>
             </div>
-            <div class="guide-section pb-3">
-              <h3 class="h6 text-uppercase text-secondary fw-semibold">4. Lire et exploiter les résultats</h3>
-              <p class="mb-2">
-                La page de résultats présente&nbsp;:
-              </p>
-              <ul class="mb-0">
-                <li>Le pourcentage de gain estimé pour les blancs dans la position actuelle.</li>
-                <li>Un classement des coups probables avec leur probabilité et l'évaluation associée.</li>
-                <li>Les métriques du modèle (tokens utilisés, coût estimé) pour suivre la consommation de l'API Hugging Face.</li>
-                <li>Le PGN analysé pour vérification rapide et partage.</li>
-              </ul>
-            </div>
-            <div class="guide-section pb-1">
-              <h3 class="h6 text-uppercase text-secondary fw-semibold">5. Dépannage rapide</h3>
-              <ul class="mb-0">
-                <li>Erreur sur <code>STOCKFISH_PATH</code>&nbsp;: vérifiez que le chemin pointe bien vers un binaire exécutable.</li>
-                <li>PGN invalide&nbsp;: corrigez la notation SAN ou la numérotation des coups avant de relancer l'analyse.</li>
-                <li>
-                  Temps de réponse ou coût élevés&nbsp;: sélectionnez un modèle Hugging Face plus léger ou ajustez les paramètres
-                  d'analyse dans <code>OracleConfig</code>.
-                </li>
-              </ul>
-            </div>
-            <p class="mt-3 mb-0 small text-secondary">
-              Retrouvez davantage de détails (modes CLI, configuration avancée, exemples) dans le fichier
-              <a
-                href="https://github.com/yoshachess/oracle/blob/main/README.md"
-                class="link-secondary"
-                target="_blank"
-                rel="noopener"
-                >README</a
-              >
-              du projet.
-            </p>
           </div>
         </div>
       </div>
     </main>
-    <footer class="container pb-5 text-center small">
-      <span>Besoin d'aide ? Consultez la documentation dans le README ou vérifiez les logs serveur pour plus de détails.</span>
+    <footer class="app-footer text-center small">
+      <div class="container-xxl px-4 px-lg-5">
+        <span>
+          Besoin d'aide ? Consultez la documentation dans le README ou vérifiez les logs serveur pour plus de détails.
+        </span>
+      </div>
     </footer>
     <script type="module" src="{{ url_for('static', path='oracle-board.js') }}"></script>
   </body>

--- a/src/oracle/web/templates/result.html
+++ b/src/oracle/web/templates/result.html
@@ -10,332 +10,227 @@
       integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
       crossorigin="anonymous"
     />
+    <link rel="stylesheet" href="{{ url_for('static', path='github-dark.css') }}" />
     <link rel="stylesheet" href="{{ url_for('static', path='oracle-board.css') }}" />
-    <style>
-      :root {
-        --github-bg: #f6f8fa;
-        --github-surface: #ffffff;
-        --github-border: #d0d7de;
-        --github-header: #24292f;
-        --github-primary: #0969da;
-        --github-success: #1a7f37;
-      }
-
-      body {
-        background-color: var(--github-bg);
-        color: #24292f;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
-          sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
-      }
-
-      .navbar {
-        background-color: var(--github-header);
-        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-      }
-
-      .navbar-brand {
-        color: #f6f8fa !important;
-        font-weight: 600;
-      }
-
-      .card {
-        border-radius: 12px;
-        border: 1px solid var(--github-border);
-        box-shadow: 0 1px 3px rgba(27, 31, 35, 0.12);
-      }
-
-      .board-panel {
-        background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
-        border: 1px solid var(--github-border);
-        border-radius: 16px;
-        padding: 1rem 1rem 1.5rem;
-        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        width: 100%;
-      }
-
-      .board-panel__header {
-        font-size: 0.875rem;
-        letter-spacing: 0.08em;
-        font-weight: 700;
-        text-transform: uppercase;
-        color: #57606a;
-        margin-bottom: 0.5rem;
-      }
-
-      .board-panel__hint {
-        font-size: 0.875rem;
-        color: #6b7280;
-        margin-top: 1rem;
-        text-align: center;
-      }
-
-      .board-summary {
-        background-color: rgba(9, 105, 218, 0.06);
-        border: 1px solid rgba(9, 105, 218, 0.18);
-        border-radius: 12px;
-        padding: 0.75rem 1rem;
-      }
-
-      .board-summary dt {
-        color: #24292f;
-        font-weight: 600;
-      }
-
-      .board-summary dd {
-        margin-bottom: 0;
-        color: #57606a;
-      }
-
-      @media (max-width: 991.98px) {
-        .board-summary {
-          margin-top: 1rem;
-        }
-
-        .board-panel {
-          margin: 0 auto;
-        }
-      }
-
-      .table {
-        border-color: var(--github-border);
-      }
-
-      .badge.bg-success {
-        background-color: var(--github-success) !important;
-      }
-
-      pre {
-        background-color: var(--github-bg);
-        border: 1px solid var(--github-border);
-        border-radius: 8px;
-        padding: 1rem;
-        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-      }
-
-      .btn-primary {
-        background-color: var(--github-primary);
-        border-color: var(--github-primary);
-        font-weight: 600;
-      }
-
-      .btn-primary:hover {
-        background-color: #0a5bd3;
-        border-color: #0a5bd3;
-      }
-    </style>
   </head>
-  <body>
-    <nav class="navbar navbar-dark">
-      <div class="container">
+  <body class="app-shell">
+    <nav class="app-nav navbar navbar-dark">
+      <div class="container-xxl px-4 px-lg-5">
         <a class="navbar-brand" href="/">Oracle Analyzer</a>
       </div>
     </nav>
-    <main class="container my-5">
-      <div class="row justify-content-center">
-        <div class="col-lg-10 col-xl-9">
-          <div class="card p-4 mb-4">
-            <div class="row g-4 align-items-start">
-              <div class="col-lg-7">
-                <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
-                  <div>
-                    <h1 class="h3 mb-2">Résultats de l'analyse</h1>
-                    <p class="mb-0 text-secondary">
-                      Estimation actuelle :
-                      <strong>{{ '%.2f'|format(current_win_percentage) }}%</strong> de chances pour les blancs.
-                    </p>
+    <main class="app-main">
+      <div class="container-xxl px-4 px-lg-5">
+        <div class="row g-4 justify-content-center">
+          <div class="col-12 col-xl-10 col-xxl-9">
+            <div class="card p-4 p-lg-5 mb-4">
+              <div class="row g-4 align-items-start">
+                <div class="col-lg-7">
+                  <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
+                    <div>
+                      <h1 class="h3 mb-2">Résultats de l'analyse</h1>
+                      <p class="mb-0 text-secondary">
+                        Estimation actuelle :
+                        <strong>{{ '%.2f'|format(current_win_percentage) }}%</strong> de chances pour les blancs.
+                      </p>
+                    </div>
+                    <div class="text-end">
+                      <a href="/?mode={{ active_mode or 'analyze' }}" class="btn btn-primary">Nouvelle analyse</a>
+                    </div>
                   </div>
-                  <div class="text-end">
-                    <a href="/?mode={{ active_mode or 'analyze' }}" class="btn btn-primary">Nouvelle analyse</a>
-                  </div>
-                </div>
-                {% if latest %}
-                <dl class="board-summary row g-3 mt-3 mb-0">
-                  <dt class="col-sm-5 col-lg-4">Dernier coup joué</dt>
-                  <dd class="col-sm-7 col-lg-8">{{ latest.san or 'Début de partie' }}</dd>
-                  <dt class="col-sm-5 col-lg-4">Trait</dt>
-                  <dd class="col-sm-7 col-lg-8">{{ 'Blancs' if latest.is_white_to_move else 'Noirs' }}</dd>
-                </dl>
-                {% endif %}
-              </div>
-              <div class="col-lg-5">
-                <div class="board-panel">
-                  <p class="board-panel__header mb-1">Plateau interactif</p>
-                  <div id="oracle-board"></div>
-                  <p class="board-panel__hint mb-0">
-                    Le PGN analysé est chargé automatiquement. Jouez un coup pour explorer différentes suites.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="card p-4 mb-4">
-            <h2 class="h5 mb-3">Explorer les coups</h2>
-            {% if history %}
-            {% set active_index = history|length - 1 %}
-            <ul class="nav nav-tabs flex-wrap" id="prediction-tabs" role="tablist">
-              {% for snapshot in history %}
-              {% set tab_id = 'position-' ~ loop.index0 %}
-              <li class="nav-item" role="presentation">
-                <button
-                  class="nav-link {% if loop.index0 == active_index %}active{% endif %}"
-                  id="{{ tab_id }}-tab"
-                  data-bs-toggle="tab"
-                  data-bs-target="#{{ tab_id }}"
-                  type="button"
-                  role="tab"
-                  aria-controls="{{ tab_id }}"
-                  aria-selected="{{ 'true' if loop.index0 == active_index else 'false' }}"
-                >
-                  {{ loop.index }}. {{ snapshot.san or 'Début de partie' }}
-                </button>
-              </li>
-              {% endfor %}
-            </ul>
-            <div class="tab-content pt-3" id="prediction-tabs-content">
-              {% for snapshot in history %}
-              {% set tab_id = 'position-' ~ loop.index0 %}
-              <div
-                class="tab-pane fade {% if loop.index0 == active_index %}show active{% endif %}"
-                id="{{ tab_id }}"
-                role="tabpanel"
-                aria-labelledby="{{ tab_id }}-tab"
-              >
-                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-                  <div>
-                    <h3 class="h6 mb-1">
-                      Trait aux {{ 'blancs' if snapshot.is_white_to_move else 'noirs' }}
-                    </h3>
-                    <p class="mb-0 text-secondary">
-                      PGN : {{ snapshot.san or 'Début de partie' }}
-                    </p>
-                  </div>
-                  <span class="badge bg-secondary">#{{ loop.index }}</span>
-                </div>
-                <div class="table-responsive mt-3">
-                  {% if snapshot.moves %}
-                  <table class="table table-hover align-middle">
-                    <thead class="table-light">
-                      <tr>
-                        <th scope="col">#</th>
-                        <th scope="col">Coup</th>
-                        <th scope="col">Probabilité</th>
-                        <th scope="col">Évaluation</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {% for prediction in snapshot.moves %}
-                      <tr>
-                        <th scope="row">{{ loop.index }}</th>
-                        <td>
-                          <span class="fw-semibold">{{ prediction.move }}{{ prediction.notation }}</span>
-                          {% if prediction.is_best_move %}
-                          <span class="badge bg-success ms-2">Meilleur coup</span>
-                          {% endif %}
-                        </td>
-                        <td>{{ '%.2f'|format(prediction.likelihood) }}%</td>
-                        <td>
-                          <div>{{ '%.2f'|format(prediction.win_percentage) }}%</div>
-                          {% if prediction.win_percentage_by_rating %}
-                          <details class="mt-1">
-                            <summary class="small text-secondary" style="cursor: pointer;">
-                              Évaluations Elo
-                            </summary>
-                            <ul class="list-unstyled small text-secondary ms-3 mb-0">
-                              {% for rating, percentage in prediction.win_percentage_by_rating|dictsort %}
-                              <li>
-                                <span class="fw-semibold">Elo {{ rating }}</span>
-                                : {{ '%.2f'|format(percentage) }}%
-                              </li>
-                              {% endfor %}
-                            </ul>
-                          </details>
-                          {% endif %}
-                        </td>
-                      </tr>
-                      {% endfor %}
-                    </tbody>
-                  </table>
-                  {% else %}
-                  <p class="mb-0 text-secondary">
-                    Aucun coup légal disponible pour cette position.
-                  </p>
+                  {% if latest %}
+                  <dl class="board-summary row g-3 mt-3 mb-0">
+                    <dt class="col-sm-5 col-lg-4">Dernier coup joué</dt>
+                    <dd class="col-sm-7 col-lg-8">{{ latest.san or 'Début de partie' }}</dd>
+                    <dt class="col-sm-5 col-lg-4">Trait</dt>
+                    <dd class="col-sm-7 col-lg-8">{{ 'Blancs' if latest.is_white_to_move else 'Noirs' }}</dd>
+                  </dl>
                   {% endif %}
                 </div>
-                <p class="mt-3 mb-0 text-secondary">
-                  Évaluation actuelle :
-                  <strong>{{ '%.2f'|format(snapshot.current_win_percentage) }}%</strong>
-                  de chances pour les blancs.
-                </p>
-              </div>
-              {% endfor %}
-            </div>
-            {% else %}
-            <p class="mb-0 text-secondary">
-              Aucune prédiction n'a pu être générée pour ce PGN.
-            </p>
-            {% endif %}
-          </div>
-
-          <div class="card p-4 mb-4">
-            <h2 class="h5 mb-3">PGN analysé</h2>
-            <pre class="mb-0" data-pgn-display>{{ pgn }}</pre>
-          </div>
-
-          <div class="card p-4">
-            <h2 class="h5 mb-3">Métriques du modèle</h2>
-            <div class="row g-3">
-              <div class="col-md-4">
-                <div class="p-3 border rounded-3 bg-light">
-                  <div class="text-secondary text-uppercase small fw-semibold">Tokens entrants</div>
-                  <div class="fs-4 fw-bold">{{ metrics.input_tokens }}</div>
-                </div>
-              </div>
-              <div class="col-md-4">
-                <div class="p-3 border rounded-3 bg-light">
-                  <div class="text-secondary text-uppercase small fw-semibold">Tokens sortants</div>
-                  <div class="fs-4 fw-bold">{{ metrics.output_tokens }}</div>
-                </div>
-              </div>
-              <div class="col-md-4">
-                <div class="p-3 border rounded-3 bg-light">
-                  <div class="text-secondary text-uppercase small fw-semibold">Coût estimé</div>
-                  <div class="fs-4 fw-bold">${{ '%.6f'|format(metrics.cost) }}</div>
+                <div class="col-lg-5">
+                  <div class="board-panel">
+                    <p class="board-panel__header mb-1">Plateau interactif</p>
+                    <div id="oracle-board"></div>
+                    <p class="board-panel__hint mb-0">
+                      Le PGN analysé est chargé automatiquement. Jouez un coup pour explorer différentes suites.
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div class="card p-4 mt-4">
-            <h2 class="h5 mb-3">Aller plus loin</h2>
-            <p class="mb-3 text-secondary">
-              Pour adapter Oracle à vos scénarios (préparation, entraînement ou diffusion), inspirez-vous des recommandations de
-              la documentation&nbsp;:
-            </p>
-            <ul class="mb-3">
-              <li>
-                Ajustez les paramètres d'analyse dans <code>OracleConfig</code> pour modifier profondeur, temps ou Elo et coller
-                au format de partie que vous étudiez.
-              </li>
-              <li>
-                Expérimentez avec différents modèles Hugging Face en surchargeant les variables
-                <code>HUGGINGFACE_MODEL_ID</code> et <code>HUGGINGFACEHUB_API_TOKEN</code>.
-              </li>
-              <li>
-                Capitalisez sur les résultats en exportant de nouveaux PGN ou en les comparant avec vos bases de données pour
-                identifier des plans alternatifs.
-              </li>
-            </ul>
-            <p class="mb-0 small text-secondary">
-              Besoin d'un rappel sur la configuration complète&nbsp;? Retournez sur la page d'accueil pour consulter le guide
-              détaillé ou ouvrez le README du projet.
-            </p>
+
+            <div class="card p-4 p-lg-5 mb-4">
+              <h2 class="h5 mb-3">Explorer les coups</h2>
+              {% if history %}
+              {% set active_index = history|length - 1 %}
+              <ul class="nav nav-tabs flex-wrap" id="prediction-tabs" role="tablist">
+                {% for snapshot in history %}
+                {% set tab_id = 'position-' ~ loop.index0 %}
+                <li class="nav-item" role="presentation">
+                  <button
+                    class="nav-link {% if loop.index0 == active_index %}active{% endif %}"
+                    id="{{ tab_id }}-tab"
+                    data-bs-toggle="tab"
+                    data-bs-target="#{{ tab_id }}"
+                    type="button"
+                    role="tab"
+                    aria-controls="{{ tab_id }}"
+                    aria-selected="{{ 'true' if loop.index0 == active_index else 'false' }}"
+                  >
+                    {{ loop.index }}. {{ snapshot.san or 'Début de partie' }}
+                  </button>
+                </li>
+                {% endfor %}
+              </ul>
+              <div class="tab-content pt-3" id="prediction-tabs-content">
+                {% for snapshot in history %}
+                {% set tab_id = 'position-' ~ loop.index0 %}
+                <div
+                  class="tab-pane fade {% if loop.index0 == active_index %}show active{% endif %}"
+                  id="{{ tab_id }}"
+                  role="tabpanel"
+                  aria-labelledby="{{ tab_id }}-tab"
+                >
+                  <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                    <div>
+                      <h3 class="h6 mb-1">
+                        Trait aux {{ 'blancs' if snapshot.is_white_to_move else 'noirs' }}
+                      </h3>
+                      <p class="mb-0 text-secondary">
+                        PGN : {{ snapshot.san or 'Début de partie' }}
+                      </p>
+                    </div>
+                    <span class="badge bg-secondary">#{{ loop.index }}</span>
+                  </div>
+                  <div class="table-responsive mt-3">
+                    {% if snapshot.moves %}
+                    <table class="table table-hover align-middle">
+                      <thead class="table-light">
+                        <tr>
+                          <th scope="col">#</th>
+                          <th scope="col">Coup</th>
+                          <th scope="col">Probabilité</th>
+                          <th scope="col">Évaluation</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {% for prediction in snapshot.moves %}
+                        <tr>
+                          <th scope="row">{{ loop.index }}</th>
+                          <td>
+                            <span class="fw-semibold">{{ prediction.move }}{{ prediction.notation }}</span>
+                            {% if prediction.is_best_move %}
+                            <span class="badge bg-success ms-2">Meilleur coup</span>
+                            {% endif %}
+                          </td>
+                          <td>{{ '%.2f'|format(prediction.likelihood) }}%</td>
+                          <td>
+                            <div>{{ '%.2f'|format(prediction.win_percentage) }}%</div>
+                            {% if prediction.win_percentage_by_rating %}
+                            <details class="mt-1">
+                              <summary class="small text-secondary">
+                                Évaluations Elo
+                              </summary>
+                              <ul class="list-unstyled small text-secondary ms-3 mb-0">
+                                {% for rating, percentage in prediction.win_percentage_by_rating|dictsort %}
+                                <li>
+                                  <span class="fw-semibold">Elo {{ rating }}</span>
+                                  : {{ '%.2f'|format(percentage) }}%
+                                </li>
+                                {% endfor %}
+                              </ul>
+                            </details>
+                            {% endif %}
+                          </td>
+                        </tr>
+                        {% endfor %}
+                      </tbody>
+                    </table>
+                    {% else %}
+                    <p class="mb-0 text-secondary">
+                      Aucun coup légal disponible pour cette position.
+                    </p>
+                    {% endif %}
+                  </div>
+                  <p class="mt-3 mb-0 text-secondary">
+                    Évaluation actuelle :
+                    <strong>{{ '%.2f'|format(snapshot.current_win_percentage) }}%</strong>
+                    de chances pour les blancs.
+                  </p>
+                </div>
+                {% endfor %}
+              </div>
+              {% else %}
+              <p class="mb-0 text-secondary">
+                Aucune prédiction n'a pu être générée pour ce PGN.
+              </p>
+              {% endif %}
+            </div>
+
+            <div class="card p-4 p-lg-5 mb-4">
+              <h2 class="h5 mb-3">PGN analysé</h2>
+              <pre class="mb-0" data-pgn-display>{{ pgn }}</pre>
+            </div>
+
+            <div class="card p-4 p-lg-5">
+              <h2 class="h5 mb-3">Métriques du modèle</h2>
+              <div class="row g-3">
+                <div class="col-md-4">
+                  <div class="p-3 border rounded-3 bg-light">
+                    <div class="text-secondary text-uppercase small fw-semibold">Tokens entrants</div>
+                    <div class="fs-4 fw-bold">{{ metrics.input_tokens }}</div>
+                  </div>
+                </div>
+                <div class="col-md-4">
+                  <div class="p-3 border rounded-3 bg-light">
+                    <div class="text-secondary text-uppercase small fw-semibold">Tokens sortants</div>
+                    <div class="fs-4 fw-bold">{{ metrics.output_tokens }}</div>
+                  </div>
+                </div>
+                <div class="col-md-4">
+                  <div class="p-3 border rounded-3 bg-light">
+                    <div class="text-secondary text-uppercase small fw-semibold">Coût estimé</div>
+                    <div class="fs-4 fw-bold">${{ '%.6f'|format(metrics.cost) }}</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="card p-4 p-lg-5 mt-4">
+              <h2 class="h5 mb-3">Aller plus loin</h2>
+              <p class="mb-3 text-secondary">
+                Pour adapter Oracle à vos scénarios (préparation, entraînement ou diffusion), inspirez-vous des recommandations de
+                la documentation&nbsp;:
+              </p>
+              <ul class="mb-3">
+                <li>
+                  Ajustez les paramètres d'analyse dans <code>OracleConfig</code> pour modifier profondeur, temps ou Elo et coller
+                  au format de partie que vous étudiez.
+                </li>
+                <li>
+                  Expérimentez avec différents modèles Hugging Face en surchargeant les variables
+                  <code>HUGGINGFACE_MODEL_ID</code> et <code>HUGGINGFACEHUB_API_TOKEN</code>.
+                </li>
+                <li>
+                  Capitalisez sur les résultats en exportant de nouveaux PGN ou en les comparant avec vos bases de données pour
+                  identifier des plans alternatifs.
+                </li>
+              </ul>
+              <p class="mb-0 small text-secondary">
+                Besoin d'un rappel sur la configuration complète&nbsp;? Retournez sur la page d'accueil pour consulter le guide
+                détaillé ou ouvrez le README du projet.
+              </p>
+            </div>
           </div>
         </div>
       </div>
     </main>
+    <footer class="app-footer text-center small">
+      <div class="container-xxl px-4 px-lg-5">
+        <span>
+          Besoin d'aide ? Consultez la documentation dans le README ou vérifiez les logs serveur pour plus de détails.
+        </span>
+      </div>
+    </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
     <script type="module" src="{{ url_for('static', path='oracle-board.js') }}"></script>
     <script type="module">


### PR DESCRIPTION
## Summary
- refresh the GitHub dark theme overrides with a full app shell, gradient background, and GitHub-style button states
- expand the index and result templates into full-width responsive shells with themed navigation and footer elements
- align the results tables, guides and metrics cards with the updated palette for a cohesive GitHub Dark experience

## Testing
- poetry run ruff check . --fix *(fails: No module named 'packaging.licenses')*
- poetry run pytest *(fails: No module named 'packaging.licenses')*

------
https://chatgpt.com/codex/tasks/task_e_68d09d9511cc8327a5eaf41323c0a20b