### PR TITLE
Fix mode selector query in template

### DIFF
--- a/src/oracle/web/templates/index.html
+++ b/src/oracle/web/templates/index.html
@@ -388,7 +388,7 @@
 
 
         commenceButton.addEventListener('click', () => {
-          const selectedMode = document.querySelector('input[name="oracle-mode']:checked').value;
+          const selectedMode = document.querySelector('input[name="oracle-mode"]:checked').value;
           let selectedLevel = '';
 
           if (selectedMode === 'analyze') {


### PR DESCRIPTION
## Summary
- fix the attribute selector used when reading the active mode so the string closes the attribute filter properly

## Testing
- `poetry run ruff check . --fix` *(fails: No module named 'packaging.licenses')*
- `poetry run pytest` *(fails: No module named 'packaging.licenses')*

------
https://chatgpt.com/codex/tasks/task_e_68d0d16de22c8327b6d95ad379256aef