### PR TITLE
Ensure poetry uses packaging 24.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -801,14 +801,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.2"
+version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
-    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
+    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
 
 [[package]]
@@ -1605,4 +1605,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "f1edf7a149aa4a652ee38aa27f269732ad469e28aa59b364b4fac8093718ec48"
+content-hash = "7b021eb9af5c0b253830d14d5d1ed969c19123a2d5baec5a6a892c8334a149ba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ uvicorn = "^0.30.0"
 jinja2 = "^3.1.4"
 python-multipart = "^0.0.9"
 tabulate = "^0.9.0"
+packaging = "^24.2"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- add a direct dependency on packaging 24.2 so the Poetry CLI can import `packaging.licenses`
- regenerate the lock file to pin the updated packaging release

## Testing
- poetry run mypy src/ --ignore-missing-imports (fails with existing typing errors)

------
https://chatgpt.com/codex/tasks/task_e_68d2861f976883279b0d7917d21b86c8