### PR TITLE
Update Hugging Face sequence handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ L’application web d’Oracle s’appuie sur FastAPI et Jinja2 : la page d’a
 ### Prérequis
 
 1. **Moteur Stockfish** : installez Stockfish localement et exportez son chemin absolu dans la variable d’environnement `STOCKFISH_PATH`. Sans cette variable, l’interface affiche un message d’erreur détaillé permettant de corriger la configuration.
-2. **Modèle Hugging Face** : par défaut, Oracle appelle `mistralai/Mistral-7B-Instruct-v0.2`. Vous pouvez remplacer ce modèle en définissant `HUGGINGFACE_MODEL_ID` et fournir un jeton via `HUGGINGFACEHUB_API_TOKEN` si l’endpoint choisi n’accepte pas les requêtes anonymes.
+2. **Modèle Hugging Face** : par défaut, Oracle appelle `mistralai/Mistral-7B-Instruct-v0.2`. Vous pouvez remplacer ce modèle en définissant `HUGGINGFACE_MODEL_ID` et fournir un jeton via `HUGGINGFACEHUB_API_TOKEN` si l’endpoint choisi n’accepte pas les requêtes anonymes. Ajustez éventuellement `HUGGINGFACE_TOP_K` (et `HUGGINGFACE_TOP_N_TOKENS`) pour contrôler le nombre de candidats retournés par l’API d’inférence.
 3. **Paramètres par défaut** : sans variables d’environnement, Oracle s’appuie sur la configuration définie par `OracleConfig` (profondeur d’analyse, temps limite, etc.), que vous pouvez adapter dans le code si nécessaire.
 
 ### Démarrage du serveur
@@ -46,6 +46,7 @@ L’application web d’Oracle s’appuie sur FastAPI et Jinja2 : la page d’a
    export STOCKFISH_PATH=/chemin/vers/stockfish
    export HUGGINGFACEHUB_API_TOKEN=...        # optionnel
    export HUGGINGFACE_MODEL_ID=...            # optionnel
+   export HUGGINGFACE_TOP_K=20                # optionnel, nombre de candidats LLM
    ```
 
 2. Lancez le serveur local avec Uvicorn :
@@ -104,6 +105,7 @@ Un bouton permet de revenir au formulaire pour une nouvelle analyse.
 
 - Ajustez les paramètres d’analyse (temps limite, profondeur, threads) ou les valeurs par défaut des Elo et contrôles de temps en modifiant `OracleConfig`. Cela peut être utile pour adapter l’application à des contextes particuliers (par exemple des parties blitz).
   Utilisez notamment le champ `rating_buckets` pour suivre l’évaluation d’un coup selon plusieurs paliers Elo en parallèle.
+  Les champs `top_k` et `top_n_tokens` permettent de calibrer le nombre de candidats demandés au modèle Hugging Face.
 - Surcharger `HUGGINGFACE_MODEL_ID` et `HUGGINGFACEHUB_API_TOKEN` à l’exécution permet d’expérimenter avec d’autres modèles hébergés sur Hugging Face sans toucher au code.
 
 ### Dépannage rapide

--- a/src/oracle/application/ports.py
+++ b/src/oracle/application/ports.py
@@ -22,6 +22,7 @@ class SequenceProvider(Protocol):
         temperature: float | None = None,
         top_p: float | None = None,
         top_k: int | None = None,
+        top_n_tokens: int | None = None,
         repetition_penalty: float | None = None,
     ) -> list[tuple[str, float]]:
         """Return sequences along with their log probabilities."""
@@ -52,5 +53,6 @@ class PredictNextMovesUseCase(Protocol):
         selected_time_control: str | None = None,
         *,
         mode: str | None = None,
+        selected_level: int | None = None,
     ) -> PredictionResult:
         """Predict the next moves for the given PGN string."""

--- a/src/oracle/domain/__init__.py
+++ b/src/oracle/domain/__init__.py
@@ -16,6 +16,7 @@ class OracleConfig:
     temperature: float | None = 0.7
     top_p: float | None = None
     top_k: int | None = None
+    top_n_tokens: int | None = None
     repetition_penalty: float | None = None
     depth: int = 5
     prob_threshold: float = 0.001
@@ -32,9 +33,15 @@ class OracleConfig:
     available_time_controls: list[str] = field(
         default_factory=lambda: ["10+0", "180+0", "600+0", "1800+0"]
     )
+    rating_buckets: list[int] = field(default_factory=list)
+    level_time_controls: dict[int, str] = field(default_factory=dict)
     play_mode_time_control: str = "600+0"
     huggingface_client: Any | None = None
     engine_factory: Callable[[str], Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.rating_buckets:
+            self.rating_buckets = list(self.available_elos)
 
     @property
     def available_levels(self) -> tuple[int, ...]:
@@ -49,6 +56,8 @@ class OracleConfig:
 
         if mode == "play":
             return self.play_mode_time_control
+        if level in self.level_time_controls:
+            return self.level_time_controls[level]
         return self.available_time_controls[0] if self.available_time_controls else None
 
     def time_control_for_mode(self, mode: str) -> str | None:

--- a/tests/units/application/test_predict_next_moves.py
+++ b/tests/units/application/test_predict_next_moves.py
@@ -46,6 +46,7 @@ class StubSequenceProvider:
         temperature: float | None = None,
         top_p: float | None = None,
         top_k: int | None = None,
+        top_n_tokens: int | None = None,
         repetition_penalty: float | None = None,
         retries: int = 3,
     ):

--- a/tests/units/service/test_prediction_provider.py
+++ b/tests/units/service/test_prediction_provider.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from oracle.domain import PredictionMetrics
+from oracle.service.prediction import HuggingFaceSequenceProvider
+
+
+class RecordingClient:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self._call_index = 0
+
+    def text_generation(self, prompt: str, **kwargs: Any) -> Any:
+        self.requests.append(kwargs)
+        self._call_index += 1
+        if "top_n_tokens" not in kwargs:
+            return {"details": {"tokens": [{}]}}
+
+        if self._call_index == 1:
+            top_tokens = [
+                {"text": " e", "logprob": math.log(0.7)},
+                {"text": " d", "logprob": math.log(0.2)},
+            ]
+        else:
+            top_tokens = [
+                {"text": " 4", "logprob": math.log(0.6)},
+                {"text": " 5", "logprob": math.log(0.3)},
+            ]
+        return {"details": {"tokens": [{"top_tokens": top_tokens}]}}
+
+
+def test_provider_requests_top_tokens_and_returns_sequences() -> None:
+    client = RecordingClient()
+    provider = HuggingFaceSequenceProvider(client)
+    metrics = PredictionMetrics()
+
+    sequences = provider.get_top_sequences(
+        "[Event \"?\"]",  # prompt content is irrelevant for the stub
+        ["e4", "d4"],
+        depth=2,
+        metrics=metrics,
+        prob_threshold=0.05,
+        top_k=3,
+        top_n_tokens=None,
+    )
+
+    requested_candidates = [call.get("top_n_tokens") for call in client.requests]
+    assert requested_candidates
+    assert all(value == 3 for value in requested_candidates)
+
+    returned_moves = {move for move, _ in sequences}
+    assert {"e4", "d4"}.issubset(returned_moves)
+    assert all(logprob <= 0 for _, logprob in sequences)
+    assert metrics.input_tokens >= 0
+    assert metrics.output_tokens >= 0

--- a/tests/units/test_oracle_one_move.py
+++ b/tests/units/test_oracle_one_move.py
@@ -24,6 +24,7 @@ class StubSequenceProvider:
         temperature: float | None = None,
         top_p: float | None = None,
         top_k: int | None = None,
+        top_n_tokens: int | None = None,
         repetition_penalty: float | None = None,
     ) -> list[tuple[str, float]]:
         self.calls.append((prompt, tuple(legal_moves), depth))

--- a/tests/units/web/test_app.py
+++ b/tests/units/web/test_app.py
@@ -43,6 +43,7 @@ class StubSequenceProvider:
         temperature: float | None = None,
         top_p: float | None = None,
         top_k: int | None = None,
+        top_n_tokens: int | None = None,
         repetition_penalty: float | None = None,
     ) -> list[tuple[str, float]]:
         self.calls.append((prompt, tuple(legal_moves), depth))


### PR DESCRIPTION
## Summary
- request top tokens from the Hugging Face client by wiring top_n_tokens through the service, configuration, and new environment variables
- extend prediction configuration and use case plumbing to honor rating buckets and selected levels, including validation and level-aware time controls
- update the FastAPI endpoints and documentation to surface the new controls and add a regression test that exercises the top-token logic

## Testing
- PYTHONPATH=vendor poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d28ec4507c832790e307199beb0296