### PR TITLE
Fix: satisfy mypy and extend CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -81,6 +84,7 @@ jobs:
         working-directory: src/oracle/web/frontend
 
   build:
+    if: github.event_name != 'pull_request'
     name: Build site
     runs-on: ubuntu-latest
     needs: test
@@ -244,6 +248,7 @@ jobs:
           path: public
 
   deploy:
+    if: github.event_name != 'pull_request'
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest

--- a/src/oracle/core/pgn.py
+++ b/src/oracle/core/pgn.py
@@ -22,6 +22,8 @@ def extract_moves_from_pgn(pgn_content: str) -> List[Move]:
 
     # Get first game from pgn (https://python-chess.readthedocs.io/en/latest/pgn.html)
     first_game = chess.pgn.read_game(io_pgn_content)
+    if first_game is None:
+        return []
 
     # Get uci moves from mainline (can have variations)
     main_moves = first_game.mainline_moves()

--- a/src/oracle/domain/services.py
+++ b/src/oracle/domain/services.py
@@ -64,8 +64,9 @@ def clean_pgn(pgn: str) -> str:
             last_dot_index = moves_str.rfind(".")
 
             move_number_start = moves_str.rfind(" ", 0, last_dot_index) + 1
-            move_number = int(moves_str[move_number_start:last_dot_index]) + 1
-            moves_str += f" {move_number}."
+            move_number_text = moves_str[move_number_start:last_dot_index]
+            next_move_number = int(move_number_text) + 1
+            moves_str += f" {next_move_number}."
 
     moves = moves_str.split(" ") if moves_str else []
 
@@ -90,10 +91,10 @@ def parse_time_control(time_control: str) -> int:
 
     for i, phase in enumerate(phases):
         if "/" in phase:
-            moves, base_increment = phase.split("/")
+            moves_text, base_increment = phase.split("/")
             base_time = int(base_increment.split("+")[0])
-            moves = int(moves)
-            total_time += base_time + (moves * increments[i])
+            moves_count = int(moves_text)
+            total_time += base_time + (moves_count * increments[i])
         else:
             base_time = int(phase.split("+")[0])
             if i == len(phases) - 1:

--- a/src/oracle/service/prediction.py
+++ b/src/oracle/service/prediction.py
@@ -397,10 +397,9 @@ class StockfishMoveAnalyzer(MoveAnalyzer):
                     eval_value: float | str = f"mate:{eval_score.mate()}"
                 else:
                     raw_score = eval_score.score()
-                    if raw_score is None:
-                        score_value = 0.0
-                    else:
-                        score_value = _clamp_score(float(raw_score))
+                    score_value = (
+                        0.0 if raw_score is None else _clamp_score(float(raw_score))
+                    )
                     if board.turn == chess.BLACK:
                         score_value = -score_value
                     eval_value = score_value

--- a/src/oracle/service/prediction.py
+++ b/src/oracle/service/prediction.py
@@ -396,7 +396,11 @@ class StockfishMoveAnalyzer(MoveAnalyzer):
                 if eval_score.is_mate():
                     eval_value: float | str = f"mate:{eval_score.mate()}"
                 else:
-                    score_value = _clamp_score(eval_score.score())
+                    raw_score = eval_score.score()
+                    if raw_score is None:
+                        score_value = 0.0
+                    else:
+                        score_value = _clamp_score(float(raw_score))
                     if board.turn == chess.BLACK:
                         score_value = -score_value
                     eval_value = score_value

--- a/src/oracle/web/app.py
+++ b/src/oracle/web/app.py
@@ -299,7 +299,7 @@ async def analyze(
     raw_mode = (mode or "").strip()
     active_mode, _ = _resolve_analysis_mode(raw_mode or None)
     analysis_form_mode = _analysis_form_mode(active_mode)
-    base_context = {
+    base_context: dict[str, Any] = {
         "request": request,
         "pgn": normalized_pgn,
         "elos": elos,
@@ -467,9 +467,8 @@ async def analyze(
         "current_win_percentage": prediction.current_win_percentage,
         "metrics": prediction.metrics,
     }
-    link_mode = raw_mode or MODE_ALIASES.get(
-        base_context.get("active_mode"), base_context.get("active_mode")
-    )
+    default_mode = MODE_ALIASES.get(active_mode, active_mode)
+    link_mode = raw_mode or default_mode
     context["active_mode"] = link_mode
     return templates.TemplateResponse(request, "result.html", context)
 
@@ -539,7 +538,7 @@ async def play_next_move(payload: PlayMoveRequest) -> JSONResponse:
             hint=exc.hint,
         )
 
-    execution_kwargs = {"mode": "play"}
+    execution_kwargs: dict[str, Any] = {"mode": "play"}
     if selected_level is not None:
         execution_kwargs["selected_level"] = selected_level
         logger.info("[DEBUG] Using selected level: %s", selected_level)


### PR DESCRIPTION
## Summary
- guard PGN parsing for missing games and clarify move numbering/time control calculations to satisfy mypy
- ensure Stockfish evaluation handles optional scores and annotate FastAPI context handling for type safety
- trigger CI test jobs on pull requests while skipping build/deploy steps for PR runs

## Testing
- poetry run mypy src --ignore-missing-imports
- poetry run pytest


------
https://chatgpt.com/codex/tasks/task_e_68d297ad8b74832789783ba6c0f6e763